### PR TITLE
Add repository url to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,5 +10,9 @@
     "node": "node_modules/.bin/node"
   },
   "keywords": "mad science",
-  "license": "ISC"
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aredridel/node-bin"
+  }
 }


### PR DESCRIPTION
Removes an `npm` warning and allows people to use `npm repo` to get here :]